### PR TITLE
Use Github URL directly for Dataset reading

### DIFF
--- a/ProjectGame.ipynb
+++ b/ProjectGame.ipynb
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "c3ddda1a-2504-4c90-9156-b9a4b9015571",
    "metadata": {},
    "outputs": [
@@ -172,8 +172,9 @@
     "import numpy as np \n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
-    "\n",
-    "df=pd.read_csv('D:/download/VideoGamesSales.csv')\n",
+    "#load the dataset directly from the URL, so people can run the code without downloading the file, also works in Google Colab\n",
+    "url = 'https://github.com/HowardZeng123/Ph-n-t-ch-dataset-Game/raw/main/VideoGamesSales.xlsx'\n",
+    "df = pd.read_excel(url)\n",
     "# df=df[df.duplicated()]\n",
     "df=df.drop_duplicates()\n",
     "df['Region']=df['Region'].fillna('North')\n",


### PR DESCRIPTION
Instead of using the local location (which might cause some small issues for users on their local Jupyter Notebook or Google Colab), use the Github URL instead.